### PR TITLE
Remove double curly braces from /tyk/oauth/clients/{apiId} path templating

### DIFF
--- a/tyk_gateway_api.yml
+++ b/tyk_gateway_api.yml
@@ -538,7 +538,7 @@ paths:
                 enum:
                   - deleted
   
-  /tyk/oauth/clients/{{apiId}}/:
+  /tyk/oauth/clients/{apiId}:
     get:
       description: |
         Get a list of OAuth clients bound to this back end 


### PR DESCRIPTION
The path templating for `/tyk/oauth/clients/{apiId}` path contained double curly braces instead of a single curly braces.

cc/ @lonelycode 
